### PR TITLE
net/core: Add bpf_get_socket_cookie for sk_msg progs

### DIFF
--- a/include/linux/filter.h
+++ b/include/linux/filter.h
@@ -279,13 +279,19 @@ static inline bool insn_is_zext(const struct bpf_insn *insn)
  *   BPF_CMPXCHG              r0 = atomic_cmpxchg(dst_reg + off16, r0, src_reg)
  */
 
-#define BPF_ATOMIC_OP(SIZE, OP, DST, SRC, OFF)			\
+#define _BPF_ATOMIC_OP(SIZE, CODE, OP, DST, SRC, OFF)		\
 	((struct bpf_insn) {					\
-		.code  = BPF_STX | BPF_SIZE(SIZE) | BPF_ATOMIC,	\
+		.code  = CODE | BPF_SIZE(SIZE) | BPF_ATOMIC,	\
 		.dst_reg = DST,					\
 		.src_reg = SRC,					\
 		.off   = OFF,					\
 		.imm   = OP })
+
+#define BPF_ATOMIC_OP(SIZE, OP, DST, SRC, OFF)			\
+	_BPF_ATOMIC_OP(SIZE, BPF_STX, OP, DST, SRC, OFF)
+
+#define BPF_ATOMIC_LOAD_OP(SIZE, OP, DST, SRC, OFF)		\
+	_BPF_ATOMIC_OP(SIZE, BPF_LDX, OP, DST, SRC, OFF)
 
 /* Legacy alias */
 #define BPF_STX_XADD(SIZE, DST, SRC, OFF) BPF_ATOMIC_OP(SIZE, BPF_ADD, DST, SRC, OFF)

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -5538,6 +5538,7 @@ struct bpf_sock {
 	__u32 dst_ip6[4];
 	__u32 state;
 	__s32 rx_queue_mapping;
+	__u64 cookie;           /* read-only */
 };
 
 struct bpf_tcp_sock {

--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -4697,6 +4697,18 @@ static const struct bpf_func_proto bpf_get_socket_cookie_sock_ops_proto = {
 	.arg1_type	= ARG_PTR_TO_CTX,
 };
 
+BPF_CALL_1(bpf_get_socket_cookie_sk_msg, struct sk_msg *, ctx)
+{
+    return ctx->sk ? __sock_gen_cookie(ctx->sk) : 0;
+}
+
+static const struct bpf_func_proto bpf_get_socket_cookie_sk_msg_proto = {
+	.func		= bpf_get_socket_cookie_sk_msg,
+	.gpl_only	= false,
+	.ret_type	= RET_INTEGER,
+	.arg1_type	= ARG_PTR_TO_CTX_OR_NULL,
+};
+
 static u64 __bpf_get_netns_cookie(struct sock *sk)
 {
 	const struct net *net = sk ? sock_net(sk) : &init_net;
@@ -7633,6 +7645,8 @@ sk_msg_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
 		return &bpf_sk_storage_delete_proto;
 	case BPF_FUNC_get_netns_cookie:
 		return &bpf_get_netns_cookie_sk_msg_proto;
+	case BPF_FUNC_get_socket_cookie:
+		return &bpf_get_socket_cookie_sk_msg_proto;
 #ifdef CONFIG_CGROUPS
 	case BPF_FUNC_get_current_cgroup_id:
 		return &bpf_get_current_cgroup_id_proto;

--- a/tools/include/linux/filter.h
+++ b/tools/include/linux/filter.h
@@ -184,13 +184,19 @@
  *   BPF_CMPXCHG              r0 = atomic_cmpxchg(dst_reg + off16, r0, src_reg)
  */
 
-#define BPF_ATOMIC_OP(SIZE, OP, DST, SRC, OFF)			\
+#define _BPF_ATOMIC_OP(SIZE, CODE, OP, DST, SRC, OFF)		\
 	((struct bpf_insn) {					\
-		.code  = BPF_STX | BPF_SIZE(SIZE) | BPF_ATOMIC,	\
+		.code  = CODE | BPF_SIZE(SIZE) | BPF_ATOMIC,	\
 		.dst_reg = DST,					\
 		.src_reg = SRC,					\
 		.off   = OFF,					\
 		.imm   = OP })
+
+#define BPF_ATOMIC_OP(SIZE, OP, DST, SRC, OFF)			\
+	_BPF_ATOMIC_OP(SIZE, BPF_STX, OP, DST, SRC, OFF)
+
+#define BPF_ATOMIC_LOAD_OP(SIZE, OP, DST, SRC, OFF)		\
+	_BPF_ATOMIC_OP(SIZE, BPF_LDX, OP, DST, SRC, OFF)
 
 /* Legacy alias */
 #define BPF_STX_XADD(SIZE, DST, SRC, OFF) BPF_ATOMIC_OP(SIZE, BPF_ADD, DST, SRC, OFF)

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -5538,6 +5538,7 @@ struct bpf_sock {
 	__u32 dst_ip6[4];
 	__u32 state;
 	__s32 rx_queue_mapping;
+	__u64 cookie;           /* read-only */
 };
 
 struct bpf_tcp_sock {


### PR DESCRIPTION
- net/core: Add socket cookie to bpf_sock
- net/core: Add bpf_get_socket_cookie for sk_msg progs
- selftests: Update test for bpf_get_socket_cookie in sk_msg context
- include/linux: Add macro for BPF atomic loads
